### PR TITLE
ui tests: update data to be in the survey area

### DIFF
--- a/survey/tests/common-UI-tests-helpers.ts
+++ b/survey/tests/common-UI-tests-helpers.ts
@@ -126,7 +126,7 @@ export const defaultPerson2: HouseholdMember = {
     workPlaceTypeBeforeLeave: null,
     schoolPlaceType: 'hybrid',
     usualWorkPlace: {
-        name: 'Bombardier'
+        name: 'Hôtel de ville de Brossard'
     },
     usualSchoolPlace: {
         name: 'Université de Montréal, Campus de la Montagne'

--- a/survey/tests/preFilledDataSample.csv
+++ b/survey/tests/preFilledDataSample.csv
@@ -1,25 +1,19 @@
-AccessCode,PostalCode,Address,AptNumber,City,Province,AddrLat,AddrLon,Strate,Lot
-1234-1111,G1R 5H1,"700, boul. René-Lévesque Est",,Québec,Québec,46.8093767,-71.222507,1,1
-1234-1112,G1R 5H1,"700, boul. René-Lévesque Est",,Québec,Québec,46.8093767,-71.222507,1,2
-1234-1113,G1R 5H1,"700, boul. René-Lévesque Est",,Québec,Québec,46.8093767,-71.222507,1,3
-1234-1114,G1R 5H1,"700, boul. René-Lévesque Est",,Québec,Québec,46.8093767,-71.222507,1,1
-1234-1115,G1R 5H1,"700, boul. René-Lévesque Est",3A,Québec,Québec,46.8093767,-71.222507,1,2
-1234-1116,G1R 5H1,"700, boul. René-Lévesque Est",,Québec,Québec,46.8093767,-71.222507,1,3
-1111-1234,G5A 1E7,"628, chemin du Golf",,La Malbaie,Québec,47.646642,-70.15838,2,1
-1111-1235,G5A 1E7,"628, chemin du Golf",,La Malbaie,Québec,47.646642,-70.15838,2,2
-1111-1236,G5A 1E7,"628, chemin du Golf",,La Malbaie,Québec,47.646642,-70.15838,2,3
-1111-1237,G5A 1E7,"628, chemin du Golf",,La Malbaie,Québec,47.646642,-70.15838,2,4
-2222-1234,G0L 1G0,"801, route de l'Église",4,Cacouna,Québec,47.905493,-69.48648,3,1
-2222-1235,G0L 1G0,"801, route de l'Église",,Cacouna,Québec,47.905493,-69.48648,3,2
-2222-1236,G0L 1G0,"801, route de l'Église",,Cacouna,Québec,47.905493,-69.48648,3,3
-2222-1237,G0L 1G0,"801, route de l'Église",,Cacouna,Québec,47.905493,-69.48648,3,4
-2222-1238,G0L 1G0,"801, route de l'Église",,Cacouna,Québec,47.905493,-69.48648,3,5
-7357-1111,G1R 5H1,"700, boul. René-Lévesque Est",,Québec,Québec,46.8093767,-71.222507,1,1
-7357-1112,G1R 5H1,"700, boul. René-Lévesque Est",,Québec,Québec,46.8093767,-71.222507,1,2
-7357-1113,G1R 5H1,"700, boul. René-Lévesque Est",,Québec,Québec,46.8093767,-71.222507,1,3
-7357-1114,G5A 1E7,"628, chemin du Golf",,La Malbaie,Québec,47.646642,-70.15838,2,1
-7357-1115,G5A 1E7,"628, chemin du Golf",,La Malbaie,Québec,47.646642,-70.15838,2,2
-7357-1116,G5A 1E7,"628, chemin du Golf",,La Malbaie,Québec,47.646642,-70.15838,2,3
-7357-1117,G0L 1G0,"801, route de l'Église",4,Cacouna,Québec,47.905493,-69.48648,3,1
-7357-1118,G0L 1G0,"801, route de l'Église",,Cacouna,Québec,47.905493,-69.48648,3,2
-7357-1119,G0L 1G0,"801, route de l'Église",,Cacouna,Québec,47.905493,-69.48648,3,3
+AccessCode,PostalCode,Address,AptNumber,City,Province,AddrLat,AddrLon,Strate,Lot,testCase
+7357-1111,G1R 5H1,"1001 boulevard Robert-Bourassa",,Montréal,Québec,45.5010118,-73.5670624,1,1,one-person-no-trips
+7357-1112,G1R 5H1,"1001 boulevard Robert-Bourassa",,Montréal,Québec,45.5010118,-73.5670624,1,2,one-person-with-trips
+7357-1113,G1R 5H1,"1001 boulevard Robert-Bourassa",,Montréal,Québec,45.5010118,-73.5670624,1,3,one-person-with-trips-and-deleted-places
+7357-1114,G5A 1E7,"1001 boulevard Robert-Bourassa",,Montréal,Québec,45.5010118,-73.5670624,1,1,two-persons-no-trips
+7357-1115,G5A 1E7,"1001 boulevard Robert-Bourassa",,Montréal,Québec,45.5010118,-73.5670624,1,2,two-persons-with-trips
+7357-1116,G5A 1E7,"3100, boulevard Le Carrefour",,Laval,Québec,45.565568,-73.757695,1,3,
+7357-1117,G0L 1G0,"3100, boulevard Le Carrefour",,Laval,Québec,45.565568,-73.757695,1,1,
+7357-1118,G0L 1G0,"3100, boulevard Le Carrefour",,Laval,Québec,45.565568,-73.757695,1,2,
+7357-1119,G0L 1G0,"107, rue Laroche",,Repentigny,Québec,45.7524804,-73.450328,1,3,
+7357-1120,G0L 1G0,"107, rue Laroche",,Repentigny,Québec,45.7524804,-73.450328,1,3,
+7357-1121,G0L 1G0,"107, rue Laroche",,Repentigny,Québec,45.7524804,-73.450328,1,3,
+7357-1122,G0L 1G0,"201, place Charles-Le Moyne",,Longueuil,Québec,45.5258901,-73.521948,1,3,
+7357-1123,G0L 1G0,"201, place Charles-Le Moyne",,Longueuil,Québec,45.5258901,-73.521948,1,3,
+7357-1124,G0L 1G0,"201, place Charles-Le Moyne",,Longueuil,Québec,45.5258901,-73.521948,1,3,
+7357-1125,G0L 1G0,"3600, boul. de la Cité-des-Jeunes",,Vaudreuil,Québec,45.3896561,-74.07763,1,3,
+7357-1126,G0L 1G0,"3600, boul. de la Cité-des-Jeunes",,Vaudreuil,Québec,45.3896561,-74.07763,1,3,
+7357-1127,G0L 1G0,"3600, boul. de la Cité-des-Jeunes",,Vaudreuil,Québec,45.3896561,-74.07763,1,3,
+

--- a/survey/tests/test-one-person-with-trips-and-deleted-places.UI.spec.ts
+++ b/survey/tests/test-one-person-with-trips-and-deleted-places.UI.spec.ts
@@ -35,7 +35,7 @@ const visitedPlaces: commonUITestsHelpers.VisitedPlace[] = [
         onTheRoadArrivalType: null, // Question won't show.
         alreadyVisitedBySelfOrAnotherHouseholdMember: false,
         shortcut: null, // Question won't show.
-        name: 'Sports Expert place Ste-Foy',
+        name: 'Sports Expert Atwater',
         _previousPreviousDepartureTime: null, // Question won't show.
         _previousArrivalTime: null, // Question won't show.
         _previousDepartureTime: 32400, // 9:00 AM
@@ -50,7 +50,7 @@ const visitedPlaces: commonUITestsHelpers.VisitedPlace[] = [
         onTheRoadArrivalType: null, // Question won't show.
         alreadyVisitedBySelfOrAnotherHouseholdMember: false,
         shortcut: null, // Question won't show.
-        name: 'Tim Hortons Ste-Foy',
+        name: 'Marché Atwater',
         _previousPreviousDepartureTime: null, // Question won't show.
         _previousArrivalTime: null, // Question won't show.
         _previousDepartureTime: null, // Question won't show.

--- a/survey/tests/test-one-person-with-trips.UI.spec.ts
+++ b/survey/tests/test-one-person-with-trips.UI.spec.ts
@@ -35,7 +35,7 @@ const visitedPlaces: commonUITestsHelpers.VisitedPlace[] = [
         onTheRoadArrivalType: null, // Question won't show.
         alreadyVisitedBySelfOrAnotherHouseholdMember: false,
         shortcut: null, // Question won't show.
-        name: 'Sports Expert place Ste-Foy',
+        name: 'Sports Expert Atwater',
         _previousPreviousDepartureTime: null, // Question won't show.
         _previousArrivalTime: null, // Question won't show.
         _previousDepartureTime: 32400, // 9:00 AM

--- a/survey/tests/test-two-persons-with-work-and-shortcuts.UI.spec.ts
+++ b/survey/tests/test-two-persons-with-work-and-shortcuts.UI.spec.ts
@@ -126,7 +126,7 @@ const visitedPlacesP1: commonUITestsHelpers.VisitedPlace[] = [
         onTheRoadArrivalType: null, // Question won't show.
         alreadyVisitedBySelfOrAnotherHouseholdMember: false,
         shortcut: null, // Question won't show.
-        name: 'Bar Évasion',
+        name: 'Tabac Villeray',
         _previousPreviousDepartureTime: null, // Question won't show.
         _previousArrivalTime: null, // Question won't show.
         _previousDepartureTime: null, // Question won't show.


### PR DESCRIPTION
fixes #71

Update the prefill data to use home addresses in the survey area. For info, the addresses used are the ARTM offices, as well as a few official MTMD buildings
(https://www.quebec.ca/gouvernement/ministeres-organismes/transports/coordonnees-structure/regionales)

Update location names to match places closer to home.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixture data for survey locations and person information to reflect current test scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chairemobilite/od_mtl/pull/88)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->