### PR TITLE
libellés: mise à jour de la clé de traduction manquante

### DIFF
--- a/survey/src/survey/sections/selectPerson/customWidgets.tsx
+++ b/survey/src/survey/sections/selectPerson/customWidgets.tsx
@@ -18,7 +18,7 @@ export const selectPerson: WidgetConfig.InputRadioType = {
     inputType: 'radio',
     datatype: 'string',
     containsHtml: true,
-    label: (t: TFunction) => t('selectPerson:_activePersonId'),
+    label: (t: TFunction) => t('selectPerson:selectPerson'),
     choices: function (interview) {
         const persons = odSurveyHelper.getPersons({ interview });
         let personsRandomSequence = getResponse(interview, '_personRandomSequence') as string[] | null;


### PR DESCRIPTION
fixes #124

Les clés générés dans le fichier yaml prennent maintenant le nom du widget plutôt que le path.