### PR TITLE
omission: ajout de la conditionnelle pour toddlerDaycare

### DIFF
--- a/survey/src/survey/common/customConditionals.ts
+++ b/survey/src/survey/common/customConditionals.ts
@@ -13,7 +13,7 @@ import {
     shouldAskForNoWorkTripReason,
     shouldDisplayTripJunction
 } from './helper';
-import { isPartialSample, isStudentFromEnrolled } from './customHelpers';
+import { isPartialSample, isStudentFromEnrolled, shouldShowToddlerDayCareQuestions } from './customHelpers';
 import sdrResidencesSecondaires from '../geojson/sdr_residences_secondaires.json';
 import transitZones from '../geojson/zones_tarifaires.json';
 import { getPointZone } from './commonHelpers';
@@ -637,7 +637,7 @@ export const mostUsedMobilityAssistiveDeviceCustomConditional: WidgetConditional
 };
 
 // Custom conditional to decide whether to show the toddler daycare question
-// FIXME: Fix issue https://github.com/chairemobilite/od_mtl/issues/130
-export const toddlerDaycareCustomConditional: WidgetConditional = (interview, path) => {
-    return [true, null];
-};
+export const toddlerDaycareCustomConditional: WidgetConditional = (interview) => [
+    shouldShowToddlerDayCareQuestions(interview),
+    null
+];

--- a/survey/src/survey/common/customHelpers.ts
+++ b/survey/src/survey/common/customHelpers.ts
@@ -149,3 +149,37 @@ export const getBarriersTripPath = (interview: InterviewAttributes) =>
 
 export const getBarriersDisabilityTripPath = (interview: InterviewAttributes) =>
     getBarriersTripPathForType('_barriersDisabilityTripPath', interview, validateTripForBarrierDisabilityQuestions);
+
+// Function to decide whether to show the toddler daycare questions
+const toddlerDaycarePartialSamples = ['paidParking', 'householdType', 'respect'];
+export const shouldShowToddlerDayCareQuestions = (interview: InterviewAttributes): boolean => {
+    // Do not show if partial sample is not a valid one
+    if (!isPartialSample(interview, toddlerDaycarePartialSamples)) {
+        return false;
+    }
+    const allPersons = odSurveyHelpers.getPersonsArray({ interview });
+
+    // Make sure the household has children
+    const children = allPersons.filter(
+        (person) => typeof person.age === 'number' && person.age >= 1 && person.age <= 4
+    );
+    if (children.length === 0) {
+        // No children
+        return false;
+    }
+
+    // For all interviewable, see if there are trips for activity 'dropSomeone' or 'fetchSomeone'
+    const compatibleTrips = odSurveyHelpers
+        .getInterviewablePersonsArray({ interview })
+        .flatMap((person) =>
+            odSurveyHelpers
+                .getJourneysArray({ person })
+                .flatMap((journey) =>
+                    odSurveyHelpers
+                        .getVisitedPlacesArray({ journey })
+                        .filter((vp) => ['dropSomeone', 'fetchSomeone'].includes(vp.activity))
+                )
+        );
+    // Make visible if there are no trips to drop/fetch someone
+    return compatibleTrips.length === 0;
+};

--- a/survey/src/survey/sections/omissions/sectionConfigs.ts
+++ b/survey/src/survey/sections/omissions/sectionConfigs.ts
@@ -6,12 +6,17 @@ import { isSectionCompleted } from 'evolution-common/lib/services/questionnaire/
 import { SectionConfig } from 'evolution-common/lib/services/questionnaire/types';
 import { allPersonsTripDiariesCompleted } from '../../common/helper';
 import { widgetsNames } from './widgetsNames';
-import { isPartialSample } from '../../common/customHelpers';
+import { isPartialSample, shouldShowToddlerDayCareQuestions } from '../../common/customHelpers';
 
 export const currentSectionName: string = 'omissions';
 const previousSectionName: SectionConfig['previousSection'] = 'personsTrips';
 const nextSectionName: SectionConfig['nextSection'] = 'longDistance';
 const parentSection = 'end';
+
+const isSectionVisible = (interview) => {
+    // Visible seulement si échantillon partiel est omission ou s'il faut montrer les questions de daycare
+    return isPartialSample(interview, 'omission') || shouldShowToddlerDayCareQuestions(interview);
+};
 
 // Config for the section
 export const sectionConfig: SectionConfig = {
@@ -33,16 +38,10 @@ export const sectionConfig: SectionConfig = {
     },
     // Determine if the current section is completed
     completionConditional: function (interview) {
-        // Complété si échantillon partiel n'est pas omission ou effectivement complété
-        return (
-            !isPartialSample(interview, 'omission') ||
-            isSectionCompleted({ interview, sectionName: currentSectionName })
-        );
+        // Complété si échantillon partiel n'est pas omission, ni si les questions d'omission de déplacement garderie ne doivent pas être montrées ou effectivement complété
+        return !isSectionVisible(interview) || isSectionCompleted({ interview, sectionName: currentSectionName });
     },
-    isSectionVisible: (interview) => {
-        // Visible seulement si échantillon partiel est omission
-        return isPartialSample(interview, 'omission');
-    }
+    isSectionVisible
 };
 
 export default sectionConfig;

--- a/survey/tests/common-UI-tests-helpers.ts
+++ b/survey/tests/common-UI-tests-helpers.ts
@@ -310,7 +310,7 @@ export type LongDistanceSection = {
 };
 
 export type OmissionsSection = {
-    toddlerDaycare: 'yes' | 'no';
+    toddlerDaycare: 'yes' | 'no' | null;
     toddlerDaycareDropoff: string[] | null;
     toddlerDaycareDropoffMode: string | null;
     toddlerDaycarePickup: string[] | null;
@@ -2215,7 +2215,11 @@ export const fillOmissionsSectionTests = ({
     // Test radio widget toddlerDaycare with conditional toddlerDaycareCustomConditional with choices yesNo
     /* @link file://./../src/survey/common/conditionals.tsx */
     /* @link file://./../src/survey/common/choices.tsx */
-    testHelpers.inputRadioTest({ context, path: 'omissions.toddlerDaycare', value: omissions.toddlerDaycare });
+    if (omissions.toddlerDaycare === null) {
+        testHelpers.inputVisibleTest({ context, path: 'omissions.toddlerDaycare', isVisible: false });
+    } else {
+        testHelpers.inputRadioTest({ context, path: 'omissions.toddlerDaycare', value: omissions.toddlerDaycare });
+    }
 
     // Test checkbox widget toddlerDaycareDropoff with conditional toddlerDaycareConditional with choices yesNo
     /* @link file://./../src/survey/common/conditionals.tsx */

--- a/survey/tests/preFilledDataSample.csv
+++ b/survey/tests/preFilledDataSample.csv
@@ -5,9 +5,11 @@ AccessCode,PostalCode,Address,AptNumber,City,Province,AddrLat,AddrLon,Strate,Lot
 7357-1114,G5A 1E7,1001 boulevard Robert-Bourassa,,Montréal,Québec,45.5010118,-73.5670624,1,1,two-persons-no-trips-hhTypeEp,householdType,FALSE,FALSE
 7357-1115,G5A 1E7,1001 boulevard Robert-Bourassa,,Montréal,Québec,45.5010118,-73.5670624,1,2,two-persons-with-trips,mtmd,FALSE,FALSE
 7357-1116,H3B 0A7,1001 boulevard Robert-Bourassa,,Montréal,Québec,45.565568,-73.757695,1,3,one-person-no-trips-and-omission-exclusive,omission,FALSE,FALSE
+7357-2116,H3B 0A7,1001 boulevard Robert-Bourassa,,Montréal,Québec,45.565568,-73.757695,1,3,test-one-adult-with-child-and-trips-householdTypeEp,householdType,FALSE,FALSE
+7357-3116,H3B 0A7,1001 boulevard Robert-Bourassa,,Montréal,Québec,45.565568,-73.757695,1,3,test-one-adult-with-children-no-trips-paidParkingEp,paidParking,FALSE,FALSE
 7357-1117,G0L 1G0,"3100, boulevard Le Carrefour",,Laval,Québec,45.565568,-73.757695,1,1,,,,
 7357-1118,G0L 1G0,"3100, boulevard Le Carrefour",,Laval,Québec,45.565568,-73.757695,1,2,,,,
-7357-1119,J6A 8G4,"107, rue Laroche",,Repentigny,Québec,45.7524804,-73.450328,1,3,one-person-no-trips-and-omission-exclusive,freqAttitudinalBarriers,FALSE,FALSE
+7357-1119,J6A 8G4,"107, rue Laroche",,Repentigny,Québec,45.7524804,-73.450328,1,3,one-person-no-trips-and-freqAttitudinalBarriersEp,freqAttitudinalBarriers,FALSE,FALSE
 7357-1120,J6A 8G4,"107, rue Laroche",,Repentigny,Québec,45.7524804,-73.450328,1,3,one-person-with-trips-freqBarriers,freqBarriers,FALSE,FALSE
 7357-1121,G0L 1G0,"107, rue Laroche",,Repentigny,Québec,45.7524804,-73.450328,1,3,,,,
 7357-1122,G0L 1G0,"201, place Charles-Le Moyne",,Longueuil,Québec,45.5258901,-73.521948,1,3,,,,

--- a/survey/tests/test-one-adult-with-child-and-trips-householdTypeEp.spec.ts
+++ b/survey/tests/test-one-adult-with-child-and-trips-householdTypeEp.spec.ts
@@ -1,0 +1,233 @@
+// eslint-disable-next-line n/no-extraneous-import
+import { test } from '@playwright/test';
+import _cloneDeep from 'lodash/cloneDeep';
+import * as testHelpers from 'evolution-frontend/tests/ui-testing/testHelpers';
+import * as surveyTestHelpers from 'evolution-frontend/tests/ui-testing/surveyTestHelpers';
+import { SurveyObjectDetector } from 'evolution-frontend/tests/ui-testing/SurveyObjectDetectors';
+import * as commonUITestsHelpers from './common-UI-tests-helpers';
+
+const context = {
+    page: null as any,
+    objectDetector: new SurveyObjectDetector(),
+    title: '',
+    widgetTestCounters: {}
+};
+
+// Survey credentials, no long distance section, no trips, one person in the
+// household, should go to omissions section.
+const postalCode = 'H3B 0A7';
+const accessCode = '7357-2116';
+
+// Configure the tests to run in serial mode (one after the other)
+test.describe.configure({ mode: 'serial' });
+
+// Initialize the test page and add it to the context
+test.beforeAll(async ({ browser }) => {
+    context.page = await testHelpers.initializeTestPage(browser, context.objectDetector);
+});
+
+test.afterAll(async () => {
+    // Delete the participant after the test
+    await commonUITestsHelpers.deleteParticipantInterview(accessCode);
+});
+
+// Define the visited places for this test scenario: dropped the child at a daycare, then went shopping, then home
+const visitedPlaces: commonUITestsHelpers.VisitedPlace[] = [
+    {
+        activityCategory: 'dropFetchSomeone',
+        activity: 'dropSomeone',
+        onTheRoadDepartureType: null, // Question won't show.
+        onTheRoadArrivalType: null, // Question won't show.
+        alreadyVisitedBySelfOrAnotherHouseholdMember: null, // Question won't show.
+        shortcut: null, // Question won't show.
+        name: 'Centre de la petite enfance de mon coeur',
+        _previousPreviousDepartureTime: null, // Question won't show.
+        _previousArrivalTime: null, // Question won't show.
+        _previousDepartureTime: 32400, // 9:00 AM
+        arrivalTime: 34200, // 9:30 AM
+        nextPlaceCategory: 'visitedAnotherPlace',
+        departureTime: 34500 // 9:35 AM
+    },
+    {
+        activityCategory: 'shoppingServiceRestaurant',
+        activity: 'shopping',
+        onTheRoadDepartureType: null, // Question won't show.
+        onTheRoadArrivalType: null, // Question won't show.
+        alreadyVisitedBySelfOrAnotherHouseholdMember: null, // Question won't show.
+        shortcut: null, // Question won't show.
+        name: 'Sports Expert Atwater',
+        _previousPreviousDepartureTime: null, // Question won't show.
+        _previousArrivalTime: null, // Question won't show.
+        _previousDepartureTime: null, // 9:00 AM
+        arrivalTime: 36000, // 10:00 AM
+        nextPlaceCategory: 'wentBackHome',
+        departureTime: 39600 // 11:00 AM
+    },
+    {
+        activityCategory: 'home',
+        activity: null, // Question won't show.
+        onTheRoadDepartureType: null, // Question won't show.
+        onTheRoadArrivalType: null, // Question won't show.
+        alreadyVisitedBySelfOrAnotherHouseholdMember: null, // Question won't show.
+        shortcut: null, // Question won't show.
+        name: null, // Question won't show.
+        _previousPreviousDepartureTime: null, // Question won't show.
+        _previousArrivalTime: null, // Question won't show.
+        _previousDepartureTime: null, // Question won't show.
+        arrivalTime: 41400, // 11:30 AM
+        nextPlaceCategory: 'stayedThereUntilTheNextDay',
+        departureTime: null // Question won't show.
+    }
+];
+
+// Define the segments for this test scenario
+const segments: commonUITestsHelpers.Segment[] = [
+    {
+        ...commonUITestsHelpers.defaultSegmentNullValues,
+        segmentIndex: 0,
+        modePre: 'taxi',
+        mode: 'taxi',
+        hasNextMode: false
+    },
+    {
+        ...commonUITestsHelpers.defaultSegmentNullValues,
+        segmentIndex: 0,
+        modePre: 'walk',
+        mode: null,
+        hasNextMode: false
+    },
+    {
+        ...commonUITestsHelpers.defaultSegmentNullValues,
+        segmentIndex: 0,
+        modePre: 'bicycle',
+        mode: 'bicycle',
+        hasNextMode: false
+    }
+];
+
+/********** Start the survey **********/
+// Start the survey using an access code and postal code combination
+surveyTestHelpers.startAndLoginWithAccessAndPostalCodes({
+    context,
+    title: 'Perspectives Mobilité 2026',
+    accessCode,
+    postalCode,
+    expectedToExist: true,
+    nextPageUrl: 'survey/home'
+});
+
+/********** Tests home section **********/
+commonUITestsHelpers.fillHomeSectionTests({
+    context,
+    home: {
+        ...commonUITestsHelpers.defaultHome,
+        householdSize: 2,
+        householdCarSharing: 'no',
+        householdBikesharing: 'no',
+        householdAtLeastOnePersonWithDisability: 'yes'
+    }
+});
+
+/********** Tests household section **********/
+// A non-working, non-student parent and a child
+const parent = {
+    ...commonUITestsHelpers.defaultPerson1,
+    nickname: 'Bianca',
+    carSharingMember: null, // Question won't show, set to no in home section
+    workerType: 'no',
+    studentType: 'no',
+    jobType: null,
+    workPlaceType: null,
+    workDays: null,
+    travelToWorkDays: null,
+    educationalAttainment: null,
+    occupation: 'longTermDisability',
+    bikesharingUsage: null,
+    bikesharingMembership: null
+};
+const child1 = {
+    personIndex: 0,
+    nickname: 'Oliver',
+    age: 2,
+    gender: null,
+    genderCustom: null,
+    drivingLicenseOwnership: null,
+    carSharingMember: null,
+    usedTransitInLast30Days: null,
+    transitPass: null,
+    transitFare: null,
+    transitFareWarning: null,
+    hasDisability: 'no',
+    disabilities: null,
+    disabilitiesSpecify: null,
+    mobilityAssistiveDevices: null,
+    mobilityAssistiveDevicesSpecify: null,
+    mostUsedMobilityAssistiveDevice: null,
+    useParatransit: null,
+    useParatransitFrequency: null,
+    useParatransitTransitFrequency: null,
+    workerType: null,
+    studentType: null,
+    jobType: null,
+    workPlaceType: null,
+    workDays: null,
+    travelToWorkDays: null,
+    educationalAttainment: null,
+    occupation: null, // Question won't show.
+    bikesharingUsage: null,
+    bikesharingMembership: null
+};
+commonUITestsHelpers.fillHouseholdSectionWithMembersTests({ context, householdMembers: [parent, child1] });
+
+/********** Tests tripsIntro section **********/
+commonUITestsHelpers.fillTripsintroSectionTests({
+    context,
+    householdSize: 1,
+    hasTrips: true,
+    expectPopup: false,
+    expectedNextSection: 'visitedPlaces'
+});
+
+/********** Tests visited places section **********/
+commonUITestsHelpers.fillVisitedPlacesSectionTests({
+    context,
+    householdSize: 1,
+    visitedPlaces,
+    journeyStartsAtHome: true
+});
+
+/********** Tests segments section **********/
+commonUITestsHelpers.fillSegmentsSectionTests({
+    context,
+    householdSize: 1,
+    segments,
+    expectedNextSection: 'end'
+});
+
+/********** Tests omissions section **********/
+// Omission section is skipped as there are trips for the daycare
+
+/********** Tests end section **********/
+const endSection = {
+    ...commonUITestsHelpers.defaultEnd,
+    householdType: 'oneFamilyOnly',
+    householdTypeSpecify: 'parentWithChild'
+};
+commonUITestsHelpers.fillEndSectionTests({ context, householdSize: 2, endSection });
+
+/********** Tests completed section **********/
+commonUITestsHelpers.fillCompletedSectionTests({ context, householdSize: 2 });
+
+// Logout and log back in with same credentials, shoud log in directly
+testHelpers.logoutTest({ context });
+testHelpers.hasConsentTest({ context });
+testHelpers.startSurveyTest({ context });
+testHelpers.registerWithAccessPostalCodeTest({
+    context,
+    postalCode,
+    accessCode,
+    expectedToExist: true,
+    nextPageUrl: 'survey/completed'
+});
+
+// FIXME Validate the survey re-entry

--- a/survey/tests/test-one-adult-with-children-no-trips-paidParkingEp.spec.ts
+++ b/survey/tests/test-one-adult-with-children-no-trips-paidParkingEp.spec.ts
@@ -16,7 +16,7 @@ const context = {
 // Survey credentials, no long distance section, no trips, one person in the
 // household, should go to omissions section.
 const postalCode = 'H3B 0A7';
-const accessCode = '7357-1116';
+const accessCode = '7357-3116';
 
 // Configure the tests to run in serial mode (one after the other)
 test.describe.configure({ mode: 'serial' });
@@ -43,10 +43,89 @@ surveyTestHelpers.startAndLoginWithAccessAndPostalCodes({
 });
 
 /********** Tests home section **********/
-commonUITestsHelpers.fillHomeSectionTests({ context });
+commonUITestsHelpers.fillHomeSectionTests({
+    context,
+    home: {
+        ...commonUITestsHelpers.defaultHome,
+        householdSize: 3,
+        householdCarSharing: 'yes',
+        householdBikesharing: 'yes',
+        householdAtLeastOnePersonWithDisability: 'no'
+    }
+});
 
 /********** Tests household section **********/
-commonUITestsHelpers.fillHouseholdSectionTests({ context, householdSize: 1 });
+// A parent and 2 children
+const parent = {
+    ...commonUITestsHelpers.defaultPerson1,
+    nickname: 'Serge',
+    hasDisability: null
+};
+const child1 = {
+    personIndex: 0,
+    nickname: 'Oliver',
+    age: 2,
+    gender: null,
+    genderCustom: null,
+    drivingLicenseOwnership: null,
+    carSharingMember: null,
+    usedTransitInLast30Days: null,
+    transitPass: null,
+    transitFare: null,
+    transitFareWarning: null,
+    hasDisability: null,
+    disabilities: null,
+    disabilitiesSpecify: null,
+    mobilityAssistiveDevices: null,
+    mobilityAssistiveDevicesSpecify: null,
+    mostUsedMobilityAssistiveDevice: null,
+    useParatransit: null,
+    useParatransitFrequency: null,
+    useParatransitTransitFrequency: null,
+    workerType: null,
+    studentType: null,
+    jobType: null,
+    workPlaceType: null,
+    workDays: null,
+    travelToWorkDays: null,
+    educationalAttainment: null,
+    occupation: null, // Question won't show.
+    bikesharingUsage: null,
+    bikesharingMembership: null
+};
+const child2 = {
+    personIndex: 0,
+    nickname: 'Olivia',
+    age: 2,
+    gender: null,
+    genderCustom: null,
+    drivingLicenseOwnership: null,
+    carSharingMember: null,
+    usedTransitInLast30Days: null,
+    transitPass: null,
+    transitFare: null,
+    transitFareWarning: null,
+    hasDisability: null,
+    disabilities: null,
+    disabilitiesSpecify: null,
+    mobilityAssistiveDevices: null,
+    mobilityAssistiveDevicesSpecify: null,
+    mostUsedMobilityAssistiveDevice: null,
+    useParatransit: null,
+    useParatransitFrequency: null,
+    useParatransitTransitFrequency: null,
+    workerType: null,
+    studentType: null,
+    jobType: null,
+    workPlaceType: null,
+    workDays: null,
+    travelToWorkDays: null,
+    educationalAttainment: null,
+    occupation: null, // Question won't show.
+    bikesharingUsage: null,
+    bikesharingMembership: null
+};
+commonUITestsHelpers.fillHouseholdSectionWithMembersTests({ context, householdMembers: [parent, child1, child2] });
 
 /********** Tests tripsIntro section **********/
 commonUITestsHelpers.fillTripsintroSectionTests({
@@ -68,12 +147,17 @@ commonUITestsHelpers.fillTravelBehaviorSectionTests({
 
 /********** Tests omissions section **********/
 const omissions = _cloneDeep(commonUITestsHelpers.defaultOmissionsSection);
-// The toddler daycare should not be present as there is no child in the household
-omissions.toddlerDaycare = null;
-omissions.hasOmittedTrips = 'yes';
-omissions.hasOmittedTripsIntro = 'for your unreported trips';
-omissions.hasOmittedTripsActivity = ['work', 'shopping', 'leisure'];
-omissions.hasOmittedTripsMode = ['walk'];
+// Filling the most fields as possible, to cover all the conditional checks.
+omissions.toddlerDaycare = 'yes';
+omissions.toddlerDaycareDropoff = ['yes', 'no']; // FIXME: This should be filled with the actual values.
+omissions.toddlerDaycareDropoffMode = 'walk';
+omissions.toddlerDaycarePickup = ['yes', 'no']; // FIXME: This should be filled with the actual values.
+omissions.toddlerDaycarePickupMode = 'walk';
+// Omission block is not shown for this case
+omissions.hasOmittedTrips = null;
+omissions.hasOmittedTripsIntro = null;
+omissions.hasOmittedTripsActivity = null;
+omissions.hasOmittedTripsMode = null;
 commonUITestsHelpers.fillOmissionsSectionTests({
     context,
     householdSize: 1,

--- a/survey/tests/test-two-persons-no-trips-hhTypeEp.UI.spec.ts
+++ b/survey/tests/test-two-persons-no-trips-hhTypeEp.UI.spec.ts
@@ -127,6 +127,8 @@ commonUITestsHelpers.fillTravelBehaviorSectionTests({
     travelBehavior: travelBehaviorP2
 });
 
+// Omission section is skipped as there are no children to have toddler daycare trips.
+
 /********** Tests end section **********/
 const endSection = {
     ...commonUITestsHelpers.defaultEnd,


### PR DESCRIPTION
fixes #130

Pour s'afficher, le ménage doit avoir des enfants entre 1 et 4 ans et personne du ménage ne doit avoir fait de déplacements pour aller reconduire/chercher quelqu'un.

Ajout de tests unitaires couvrant ces cas.