### PR TITLE
uiTests: éliminer l'étape d'installation de navigateur en CI

### DIFF
--- a/.github/workflows/survey-ui-test.yml
+++ b/.github/workflows/survey-ui-test.yml
@@ -66,8 +66,6 @@ jobs:
           NODE_ENV: production
       - name: Get Playwright config
         run: cp survey/playwright-example.config.ts survey/playwright.config.ts
-      - name: Install Playwright Browsers # Use this to install the browsers needed for Playwright
-        run: yarn playwright install
       - name: Start application
         run: yarn start &
         env:


### PR DESCRIPTION
tentative de fix #165

Les tests bloquent à l'étape d'installation. Or, cette étape n'existe pas dans le CI du côté d'Evolution. En l'enlevant, ça va peut-être régler le problème.