### PR TITLE
travelBehavior: fix condition de fin pour sans lieu d'étude

### DIFF
--- a/survey/src/survey/common/customConditionals.ts
+++ b/survey/src/survey/common/customConditionals.ts
@@ -5,11 +5,7 @@ import config from 'evolution-common/lib/config/project.config';
 import { Person, WidgetConditional } from 'evolution-common/lib/services/questionnaire/types';
 import * as surveyHelper from 'evolution-common/lib/utils/helpers';
 import * as odSurveyHelper from 'evolution-common/lib/services/odSurvey/helpers';
-import {
-    shouldAskForNoSchoolTripFollowup,
-    shouldAskForNoSchoolTripReason,
-    shouldAskForNoWorkTripReason
-} from './helper';
+import { shouldAskForNoSchoolTripFollowup, shouldAskForNoWorkTripReason } from './helper';
 import { isPartialSample, shouldShowToddlerDayCareQuestions } from './customHelpers';
 import sdrResidencesSecondaires from '../geojson/sdr_residences_secondaires.json';
 import transitZones from '../geojson/zones_tarifaires.json';
@@ -117,11 +113,6 @@ export const shouldAskForNoWorkTripReasonCustomConditional: WidgetConditional = 
 export const shouldAskPersonNoWorkTripSpecifyCustomConditional: WidgetConditional = (interview, path) => {
     const reason = surveyHelper.getResponse(interview, path, null, '../noWorkTripReason');
     return [reason === 'other', null];
-};
-
-export const shouldAskForNoSchoolTripReasonCustomConditional: WidgetConditional = (interview, path) => {
-    const person = odSurveyHelper.getPerson({ interview, path });
-    return [shouldAskForNoSchoolTripReason({ interview, person }), null];
 };
 
 export const shouldAskForNoSchoolTripSpecifyCustomConditional: WidgetConditional = (interview, path) => {

--- a/survey/src/survey/common/helper.ts
+++ b/survey/src/survey/common/helper.ts
@@ -3,6 +3,7 @@ import _isEqual from 'lodash/isEqual';
 import { faCheckCircle } from '@fortawesome/free-solid-svg-icons';
 import moment from 'moment-business-days';
 import { distance as turfDistance } from '@turf/turf';
+import { isFeature } from 'geojson-validation';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import config from 'evolution-common/lib/config/project.config';
 import {
@@ -21,6 +22,7 @@ import {
     validateButtonAction,
     validateButtonActionWithCompleteSection
 } from 'evolution-frontend/lib/services/display/frontendHelper';
+import * as conditionals from './conditionals';
 
 // FIXME Move elsewhere as we start using Evolution's builtin sections. It is
 // here to be available for widgets.ts, sections.ts and questionnaire.ts files.
@@ -168,33 +170,6 @@ export const shouldAskForNoWorkTripReason = ({
     return tripsDateIsBusinessDay && getVisitedPlacesForCategory(journey, 'work').length === 0;
 };
 
-export const shouldAskForNoSchoolTripReason = ({
-    person,
-    interview
-}: {
-    person: Person;
-    interview: UserInterviewAttributes;
-}) => {
-    // Ask only for full time students
-    const journey = odSurveyHelper.getJourneysArray({ person })[0];
-    if (!person || !journey) {
-        return false;
-    }
-    const studentType = person.studentType;
-    const schoolPlaceType = person.schoolPlaceType;
-    const schoolPlaceIsCompatible =
-        ['onLocation', 'hybrid'].includes(schoolPlaceType) && ['fullTime', 'partTime'].includes(studentType);
-    const childrenCase = odSurveyHelper.isStudentFromSchoolType({ person });
-    if (!(schoolPlaceIsCompatible || childrenCase)) {
-        return false;
-    }
-
-    const tripsDate = getResponse(interview, '_assignedDay', null);
-    const tripsDateIsBusinessDay = moment(tripsDate).isBusinessDay();
-
-    return tripsDateIsBusinessDay && getVisitedPlacesForCategory(journey, 'school').length === 0;
-};
-
 export const shouldAskForNoSchoolTripFollowup = ({
     person,
     interview
@@ -239,15 +214,41 @@ const travelBehaviorForPersonComplete = function ({
     }
     // Make sure the no trip reasons are answered if required
     const shouldAskNoSchoolTrip = shouldAskForNoSchoolTripFollowup({ person, interview });
+    // Should ask school place is both shouldAskNotSchoolTrip and the conditional is `false`
+    const shouldAskSchoolPlace =
+        shouldAskNoSchoolTrip &&
+        conditionals.hasSchoolLocationNotSetConditional(interview, `household.persons.${person._uuid}`)[0];
     const shouldAskNoWorkTrip = shouldAskForNoWorkTripReason({ person, interview });
     if (!shouldAskNoSchoolTrip && !shouldAskNoWorkTrip) {
         return true;
     }
+
     const journey = odSurveyHelper.getJourneysArray({ person })[0] as any;
-    return (
-        (!shouldAskNoSchoolTrip || typeof journey.noSchoolTripReason === 'string') &&
-        (!shouldAskNoWorkTrip || typeof journey.noWorkTripReason === 'string')
-    );
+
+    // Either or both no work or school trip reasons need to be completed
+    // No work is completed if we should not ask or the noWorkTripReason is filled
+    const noWorkTripCompleted = !shouldAskNoWorkTrip || typeof journey.noWorkTripReason === 'string';
+
+    // No school trip has many completion path, encapsulate them in a function
+    const noSchoolTripCompleted = () => {
+        // Not to be asked, so it is completed
+        if (!shouldAskNoSchoolTrip) {
+            return true;
+        }
+        const hasSchoolPlaceAnswered = typeof (person as any).hasSchoolPlace === 'string';
+        // Need to fill school place type
+        if (!hasSchoolPlaceAnswered) {
+            return false;
+        }
+        // No school place to ask, it is completed
+        if (!shouldAskSchoolPlace) {
+            return true;
+        }
+        // Completed if noSchoolTripReason and geography are set
+        return typeof journey.noSchoolTripReason === 'string' && isFeature(person.usualSchoolPlace?.geography);
+    };
+
+    return noSchoolTripCompleted() && noWorkTripCompleted;
 };
 
 /**

--- a/survey/tests/common-UI-tests-helpers.ts
+++ b/survey/tests/common-UI-tests-helpers.ts
@@ -2152,7 +2152,7 @@ export const fillTravelBehaviorSectionTests = ({
             isVisible: false
         });
     } else {
-        // Test string widget personUsualSchoolPlaceName with conditional personUsualSchoolPlaceNameCustomConditional
+        // Test string widget personUsualSchoolPlaceName with conditional hasSchoolLocationNotSetConditional
         /* @link file://./../src/survey/common/conditionals.tsx */
         testHelpers.inputStringTest({
             context,
@@ -2172,7 +2172,7 @@ export const fillTravelBehaviorSectionTests = ({
     // Test custom widget personNoSchoolTripIntro
     // Implement custom test
 
-    // Test select widget personNoSchoolTripReason with conditional shouldAskForNoSchoolTripReasonCustomConditional with choices noSchoolTripReasonChoices
+    // Test select widget personNoSchoolTripReason with conditional hasSchoolLocationNotSetConditional with choices noSchoolTripReasonChoices
     /* @link file://./../src/survey/common/conditionals.tsx */
     /* @link file://./../src/survey/common/choices.tsx */
     if (travelBehavior.noSchoolTripReason === null) {

--- a/survey/tests/preFilledDataSample.csv
+++ b/survey/tests/preFilledDataSample.csv
@@ -15,7 +15,7 @@ AccessCode,PostalCode,Address,AptNumber,City,Province,AddrLat,AddrLon,Strate,Lot
 7357-1122,G0L 1G0,"201, place Charles-Le Moyne",,Longueuil,Québec,45.5258901,-73.521948,1,3,,,,
 7357-1123,G0L 1G0,"201, place Charles-Le Moyne",,Longueuil,Québec,45.5258901,-73.521948,1,3,,,,
 7357-1124,G0L 1G0,"201, place Charles-Le Moyne",,Longueuil,Québec,45.5258901,-73.521948,1,3,,,,
-7357-1125,G0L 1G0,"3600, boul. de la Cité-des-Jeunes",,Vaudreuil,Québec,45.3896561,-74.07763,1,3,,,,
-7357-1126,G0L 1G0,"3600, boul. de la Cité-des-Jeunes",,Vaudreuil,Québec,45.3896561,-74.07763,1,3,,,,
-7357-1127,G0L 1G0,"3600, boul. de la Cité-des-Jeunes",,Vaudreuil,Québec,45.3896561,-74.07763,1,3,,,,
+7357-1125,J7V 3Z5,"3600, boul. de la Cité-des-Jeunes",,Vaudreuil,Québec,45.3896561,-74.07763,1,3,one-person-no-trips-noUsualLocation-hhTypeEp,householdType,FALSE,FALSE
+7357-1126,J7V 3Z5,"3600, boul. de la Cité-des-Jeunes",,Vaudreuil,Québec,45.3896561,-74.07763,1,3,,,,
+7357-1127,J7V 3Z5,"3600, boul. de la Cité-des-Jeunes",,Vaudreuil,Québec,45.3896561,-74.07763,1,3,,,,
 1111-1112,G0L 1G0,"107, rue Laroche",,Vaudreuil,Québec,45.3896561,-74.07763,1,3,,omission,FALSE,FALSE

--- a/survey/tests/test-one-person-no-trips-noUsualLocation-hhTypeEp.UI.spec.ts
+++ b/survey/tests/test-one-person-no-trips-noUsualLocation-hhTypeEp.UI.spec.ts
@@ -1,0 +1,102 @@
+// eslint-disable-next-line n/no-extraneous-import
+import { test } from '@playwright/test';
+import _cloneDeep from 'lodash/cloneDeep';
+import * as testHelpers from 'evolution-frontend/tests/ui-testing/testHelpers';
+import * as surveyTestHelpers from 'evolution-frontend/tests/ui-testing/surveyTestHelpers';
+import { SurveyObjectDetector } from 'evolution-frontend/tests/ui-testing/SurveyObjectDetectors';
+import * as commonUITestsHelpers from './common-UI-tests-helpers';
+
+const context = {
+    page: null as any,
+    objectDetector: new SurveyObjectDetector(),
+    title: '',
+    widgetTestCounters: {}
+};
+
+// Survey credentials, no long distance section, no trips, one person in the
+// household, should go directly to end section after travel behavior.
+const postalCode = 'J7V 3Z5';
+const accessCode = '7357-1125';
+
+// Configure the tests to run in serial mode (one after the other)
+test.describe.configure({ mode: 'serial' });
+
+// Initialize the test page and add it to the context
+test.beforeAll(async ({ browser }) => {
+    context.page = await testHelpers.initializeTestPage(browser, context.objectDetector);
+});
+
+test.afterAll(async () => {
+    // Delete the participant after the test
+    await commonUITestsHelpers.deleteParticipantInterview(accessCode);
+});
+
+/********** Start the survey **********/
+// Start the survey using an access code and postal code combination
+surveyTestHelpers.startAndLoginWithAccessAndPostalCodes({
+    context,
+    title: 'Perspectives Mobilité 2026',
+    accessCode,
+    postalCode,
+    expectedToExist: true,
+    nextPageUrl: 'survey/home'
+});
+
+/********** Tests home section **********/
+commonUITestsHelpers.fillHomeSectionTests({ context });
+
+/********** Tests household section **********/
+const person = _cloneDeep(commonUITestsHelpers.defaultPerson1);
+// Person does not have a fixed work place. Also, ra is 8, so a few questions are not asked
+person.workPlaceType = 'remote';
+person.workDays = '5';
+person.travelToWorkDays = null;
+person.carSharingMember = null;
+person.bikesharingMembership = null;
+person.bikesharingUsage = null;
+commonUITestsHelpers.fillHouseholdSectionWithMembersTests({ context, householdMembers: [person] });
+
+/********** Tests tripsIntro section **********/
+commonUITestsHelpers.fillTripsintroSectionTests({
+    context,
+    householdSize: 1,
+    hasTrips: false,
+    expectPopup: false,
+    expectedNextSection: 'travelBehavior'
+});
+
+/********** Tests travelBehavior section **********/
+const travelBehavior = _cloneDeep(commonUITestsHelpers.defaultTravelBehaviorWhenNoTrip);
+// No work trip reason as it is remote, and the person has no school place
+travelBehavior.noWorkTripReason = null;
+travelBehavior.usualWorkPlace = null;
+travelBehavior.usualWorkPlaceCommuting = null;
+travelBehavior.hasSchoolPlace = 'no';
+travelBehavior.usualSchoolPlace = null;
+travelBehavior.noSchoolTripReason = null;
+commonUITestsHelpers.fillTravelBehaviorSectionTests({
+    context,
+    householdSize: 1,
+    nextSection: 'end',
+    travelBehavior
+});
+
+/********** Tests end section **********/
+commonUITestsHelpers.fillEndSectionTests({ context, householdSize: 1 });
+
+/********** Tests completed section **********/
+commonUITestsHelpers.fillCompletedSectionTests({ context, householdSize: 1 });
+
+// Logout and log back in with same credentials, shoud log in directly
+testHelpers.logoutTest({ context });
+testHelpers.hasConsentTest({ context });
+testHelpers.startSurveyTest({ context });
+testHelpers.registerWithAccessPostalCodeTest({
+    context,
+    postalCode,
+    accessCode,
+    expectedToExist: true,
+    nextPageUrl: 'survey/completed'
+});
+
+// FIXME Validate the survey re-entry


### PR DESCRIPTION
fixes #136

Si la personne est étudiante et n'a pas de déplacement étude, la section travelBehavior demande s'il y a un lieu d'études. Si non, c'est tout pour cette section. Si oui, il faut s'assurer d'avoir une géographie du lieu.

Aussi suppression de la conditionnelle `shouldAskForNoSchoolTripReason`, qui est remplacée dans cette enquête par
`shouldAskForNoSchoolTripReasonFollowup`.

Ajout d'un test UI avec une personne étudiante sans lieu d'étude fixe pour valider que la condition passe bien maintenant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved school-trip and no-work/no-school-trip follow-up logic to request the right questions based on survey state and whether a usual school location is set.
  * Refined eligibility for follow-up answers, including handling of “other” reason selections and GeoJSON location checks.
* **Tests**
  * Added a new Playwright UI spec covering the “one person, no trips, no usual location” survey journey, including re-entry to the completed page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->